### PR TITLE
58 set support implementation

### DIFF
--- a/unit-socializer-core/src/main/java/io/github/wouterbauweraerts/unitsocializer/core/factory/TypeHelper.java
+++ b/unit-socializer-core/src/main/java/io/github/wouterbauweraerts/unitsocializer/core/factory/TypeHelper.java
@@ -105,6 +105,10 @@ public class TypeHelper {
         return List.class.isAssignableFrom(typeClass);
     }
 
+    public boolean isSet(Class<?> typeClass) {
+        return Set.class.isAssignableFrom(typeClass);
+    }
+
     public Class<?> getListImplementation(Class<?> listClass) {
         if (listClass.equals(LinkedList.class)) {
             return LinkedList.class;
@@ -115,6 +119,15 @@ public class TypeHelper {
         } else {
             throw new SociableTestException("Unsupported list implementation: %s".formatted(listClass.getCanonicalName()));
         }
+    }
+
+    public Class<?> getSetImplementation(Class<?> setClass) {
+        if (setClass.equals(HashSet.class)  || setClass.equals(Set.class)) {
+            return HashSet.class;
+        } else if (setClass.equals(LinkedHashSet.class)) {
+            return LinkedHashSet.class;
+        }
+        throw new SociableTestException("Unsupported Set implementation: %s".formatted(setClass.getCanonicalName()));
     }
 
     public Class<?> getTypeClass(Type type) {

--- a/unit-socializer-core/src/main/java/io/github/wouterbauweraerts/unitsocializer/core/helpers/InstanceHelper.java
+++ b/unit-socializer-core/src/main/java/io/github/wouterbauweraerts/unitsocializer/core/helpers/InstanceHelper.java
@@ -3,10 +3,7 @@ package io.github.wouterbauweraerts.unitsocializer.core.helpers;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -170,6 +167,26 @@ public class InstanceHelper {
                 List<Object> createdList = Instancio.ofList(() -> typeArgs[0]).size(0).create();
                 createdList.addAll(elements);
                 return createdList;
+            }
+        }
+        else if (typeHelper.isSet(typeClass)) {
+            if (typeArgs.length > 1) {
+                throw new SociableTestInstantiationException("Cannot instantiate a Set with multiple generic types");
+            }
+
+            Class<?> implementation = typeHelper.getSetImplementation(typeClass);
+
+            if (typeHelper.isJavaType(typeArgs[0])) {
+                return Instancio.ofSet(() -> typeArgs[0]).subtype(root(), implementation).create();
+            } else {
+                Class<?> clazz = typeHelper.getTypeClass(typeArgs[0]);
+                Set<?> elements = typeResolver.resolveAll(clazz).stream()
+                        .map(this::instantiate)
+                        .collect(Collectors.toSet());
+
+                Set<Object> createdSet = Instancio.ofSet(() -> typeArgs[0]).size(0).create();
+                createdSet.addAll(elements);
+                return createdSet;
             }
         }
         throw new SociableTestInstantiationException("Cannot instantiate a Collection of type " + typeClass.getSimpleName());

--- a/unit-socializer-junit-mockito/src/test/java/io/github/wouterbauweraerts/unitsocializer/junit/mockito/extension/success/collection/set/DummyWithPredefinedSetTest.java
+++ b/unit-socializer-junit-mockito/src/test/java/io/github/wouterbauweraerts/unitsocializer/junit/mockito/extension/success/collection/set/DummyWithPredefinedSetTest.java
@@ -1,0 +1,57 @@
+package io.github.wouterbauweraerts.unitsocializer.junit.mockito.extension.success.collection.set;
+
+import io.github.wouterbauweraerts.unitsocializer.core.annotations.Predefined;
+import io.github.wouterbauweraerts.unitsocializer.core.annotations.TestSubject;
+import io.github.wouterbauweraerts.unitsocializer.junit.mockito.annotations.SociableTest;
+import io.github.wouterbauweraerts.unitsocializer.junit.mockito.extension.success.collection.dummy.AbstractDummy;
+import io.github.wouterbauweraerts.unitsocializer.junit.mockito.extension.success.collection.dummy.AbstractDummyImplOne;
+import io.github.wouterbauweraerts.unitsocializer.junit.mockito.extension.success.collection.dummy.AbstractDummyImplTwo;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SociableTest
+public class DummyWithPredefinedSetTest {
+
+    @Nested
+    class PredefinedBuiltInType {
+        @TestSubject
+        DummyWithSetOfIntegers subject;
+
+        @Predefined
+        Set<Integer> predefinedSet = Set.of(1, 2, 3);
+
+        public record DummyWithSetOfIntegers(Set<Integer> set) {}
+
+        @Test
+        void canInstantiateDummyWithPredefinedListOfIntegers() {
+            assertThat(subject).isNotNull();
+            assertThat(subject.set).isNotNull()
+                    .containsExactlyElementsOf(predefinedSet);
+        }
+    }
+
+    @Nested
+    class PredefinedSetWithCustomType {
+        @TestSubject
+        DummyWithSetOfCustomType subject;
+
+        @Predefined
+        Set<AbstractDummy> predefinedSet = Set.of(
+                new AbstractDummyImplOne(),
+                new AbstractDummyImplTwo()
+        );
+
+        public record DummyWithSetOfCustomType(Set<AbstractDummy> set) {}
+
+        @Test
+        void canInstantiateDummyWithPredefinedList() {
+            assertThat(subject).isNotNull();
+            assertThat(subject.set).isNotNull()
+                    .containsExactlyElementsOf(predefinedSet);
+        }
+    }
+}

--- a/unit-socializer-junit-mockito/src/test/java/io/github/wouterbauweraerts/unitsocializer/junit/mockito/extension/success/collection/set/SetupContextWithGeneratedSetTest.java
+++ b/unit-socializer-junit-mockito/src/test/java/io/github/wouterbauweraerts/unitsocializer/junit/mockito/extension/success/collection/set/SetupContextWithGeneratedSetTest.java
@@ -1,0 +1,103 @@
+package io.github.wouterbauweraerts.unitsocializer.junit.mockito.extension.success.collection.set;
+
+import io.github.wouterbauweraerts.unitsocializer.core.annotations.TestSubject;
+import io.github.wouterbauweraerts.unitsocializer.junit.mockito.annotations.SociableTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SociableTest
+public class SetupContextWithGeneratedSetTest {
+    @Nested
+    class SetOfJavaType {
+        @TestSubject
+        DummyWithJavaTypeSet subject;
+
+        @Test
+        void canInstantiateDummyWithPredefinedListOfIntegers() {
+            assertThat(subject).isNotNull();
+            assertThat(subject.set).isNotNull()
+                    .isInstanceOf(HashSet.class)
+                    .isNotEmpty()
+                    .allSatisfy(el -> assertThat(el).isInstanceOf(Integer.class));
+        }
+
+        public record DummyWithJavaTypeSet(Set<Integer> set) {
+        }
+    }
+
+    @Nested
+    class SetOfJavaTypeString {
+        @TestSubject
+        DummyWithJavaTypeSet subject;
+
+        @Test
+        void canInstantiateDummyWithPredefinedListOfIntegers() {
+            assertThat(subject).isNotNull();
+            assertThat(subject.set).isNotNull()
+                    .isInstanceOf(LinkedHashSet.class)
+                    .isNotEmpty()
+                    .allSatisfy(el -> assertThat(el).isInstanceOf(String.class));
+        }
+
+        public record DummyWithJavaTypeSet(LinkedHashSet<String> set) {
+        }
+    }
+
+    @Nested
+    class SetOfCustomType {
+        @TestSubject
+        DummyWithSetOfCustomType subject;
+
+        @Test
+        void canCreateInstanceWithListOfCustomTypeWithAllImplementations() {
+            assertThat(subject).isNotNull();
+            assertThat(subject.set).isNotNull()
+                    .isInstanceOf(HashSet.class)
+                    .hasSize(2)
+                    .satisfies(lst -> {
+                        assertThat(lst.stream().anyMatch(AbstractDummyImplOne.class::isInstance)).isTrue();
+                        assertThat(lst.stream().anyMatch(AbstractDummyImplTwo.class::isInstance)).isTrue();
+                    });
+        }
+
+        public record DummyWithSetOfCustomType(Set<AbstractDummyForGenerateSet> set) {}
+
+        public interface AbstractDummyForGenerateSet {}
+        public record AbstractDummyImplOne() implements AbstractDummyForGenerateSet {}
+        public record AbstractDummyImplTwo(int integerValue) implements AbstractDummyForGenerateSet {}
+    }
+
+    @Nested
+    @Disabled
+    class ListOfCustomGenericType {
+        @TestSubject
+        DummyWithListOfCustomGenericType subject;
+
+        @Test
+        void canCreateInstanceWithListOfCustomTypeWithAllImplementations() {
+            assertThat(subject).isNotNull();
+            assertThat(subject.list).isNotNull()
+                    .isInstanceOf(ArrayList.class)
+                    .hasSize(2)
+                    .satisfies(lst -> {
+                        assertThat(lst.stream().anyMatch(AbstractDummyImplOne.class::isInstance)).isTrue();
+                        assertThat(lst.stream().anyMatch(AbstractDummyImplTwo.class::isInstance)).isTrue();
+                    });
+        }
+
+        public record DummyWithListOfCustomGenericType(List<AbstractDummyGenericType<?>> list) {}
+
+        public interface AbstractDummyGenericType<T> {
+            T value();
+        }
+
+        public record AbstractDummyImplOne(String value) implements AbstractDummyGenericType<String> {}
+
+        public record AbstractDummyImplTwo(Integer value) implements AbstractDummyGenericType<Number> {}
+    }
+}

--- a/unit-socializer-junit-mockito/src/test/java/io/github/wouterbauweraerts/unitsocializer/junit/mockito/extension/success/collection/set/SetupContextWithGeneratedSetTest.java
+++ b/unit-socializer-junit-mockito/src/test/java/io/github/wouterbauweraerts/unitsocializer/junit/mockito/extension/success/collection/set/SetupContextWithGeneratedSetTest.java
@@ -2,11 +2,12 @@ package io.github.wouterbauweraerts.unitsocializer.junit.mockito.extension.succe
 
 import io.github.wouterbauweraerts.unitsocializer.core.annotations.TestSubject;
 import io.github.wouterbauweraerts.unitsocializer.junit.mockito.annotations.SociableTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,7 +19,7 @@ public class SetupContextWithGeneratedSetTest {
         DummyWithJavaTypeSet subject;
 
         @Test
-        void canInstantiateDummyWithPredefinedListOfIntegers() {
+        void canInstantiateDummyWithPredefinedSetOfIntegers() {
             assertThat(subject).isNotNull();
             assertThat(subject.set).isNotNull()
                     .isInstanceOf(HashSet.class)
@@ -36,7 +37,7 @@ public class SetupContextWithGeneratedSetTest {
         DummyWithJavaTypeSet subject;
 
         @Test
-        void canInstantiateDummyWithPredefinedListOfIntegers() {
+        void canInstantiateDummyWithPredefinedSetOfIntegers() {
             assertThat(subject).isNotNull();
             assertThat(subject.set).isNotNull()
                     .isInstanceOf(LinkedHashSet.class)
@@ -54,7 +55,7 @@ public class SetupContextWithGeneratedSetTest {
         DummyWithSetOfCustomType subject;
 
         @Test
-        void canCreateInstanceWithListOfCustomTypeWithAllImplementations() {
+        void canCreateInstanceWithSetOfCustomTypeWithAllImplementations() {
             assertThat(subject).isNotNull();
             assertThat(subject.set).isNotNull()
                     .isInstanceOf(HashSet.class)
@@ -73,16 +74,15 @@ public class SetupContextWithGeneratedSetTest {
     }
 
     @Nested
-    @Disabled
-    class ListOfCustomGenericType {
+    class SetOfCustomGenericType {
         @TestSubject
-        DummyWithListOfCustomGenericType subject;
+        DummyWithSetOfCustomGenericType subject;
 
         @Test
-        void canCreateInstanceWithListOfCustomTypeWithAllImplementations() {
+        void canCreateInstanceWithSetOfCustomTypeWithAllImplementations() {
             assertThat(subject).isNotNull();
-            assertThat(subject.list).isNotNull()
-                    .isInstanceOf(ArrayList.class)
+            assertThat(subject.set).isNotNull()
+                    .isInstanceOf(HashSet.class)
                     .hasSize(2)
                     .satisfies(lst -> {
                         assertThat(lst.stream().anyMatch(AbstractDummyImplOne.class::isInstance)).isTrue();
@@ -90,7 +90,7 @@ public class SetupContextWithGeneratedSetTest {
                     });
         }
 
-        public record DummyWithListOfCustomGenericType(List<AbstractDummyGenericType<?>> list) {}
+        public record DummyWithSetOfCustomGenericType(Set<AbstractDummyGenericType<?>> set) {}
 
         public interface AbstractDummyGenericType<T> {
             T value();


### PR DESCRIPTION
- Test support for predefined Set attributes
- Test and implement Set generation for multiple supported Set types: HashSet (default) and LinkedHashSet 
- generation with built-in java types
- generation with custom concrete types
- generation with custom abstract types